### PR TITLE
Add running from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
 
 ---
 
+## 💻 开发环境 / Running from source
+
+- **Python 版本要求：** 3.10 及以上（代码使用 `match` 语法）
+- **安装依赖：** `pip install -r requirements.txt`
+- **运行方式：** `python main.py`，然后按提示选择串口
+
 ## 🖥️ 使用方法
 
 ### 1. 准备

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyserial
+crcmod


### PR DESCRIPTION
## Summary
- document Python 3.10+ requirement and how to run from source
- add `requirements.txt` for pip installs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683daf3a373c832c81348fb9f1c12c5e